### PR TITLE
Add managing optolink adapter at URL / Add new channels/things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 /target/
 /.classpath
+conf/
+logs/
+.settings/
+optolink.xml
+start.bat
+start.sh
+start_debug.sh
+things-types vs optolink - comparison.xlsx
+.gitignore

--- a/pom.xml
+++ b/pom.xml
@@ -57,5 +57,5 @@
 		</dependency>
 	</dependencies>
 
-	<version>1.0.0-RC1</version>
+	<version>1.0.1</version>
 </project>

--- a/src/main/java/de/myandres/optolink/Config.java
+++ b/src/main/java/de/myandres/optolink/Config.java
@@ -39,6 +39,9 @@ public class Config {
 
 	private String adapterID="TEST"; 
 	private String tty;
+	private String ttyIP;
+	private Integer ttyPort;
+	private String ttyType;
 	private int ttyTimeOut = 2000;      //default
 	private int port = 31113;           // default: unassigned Port. See: http://www.iana.org
 	private String deviceType;
@@ -107,6 +110,37 @@ public class Config {
 		return tty;
 	}
 
+	private void setTTYType(String s) {
+		ttyType = s;
+		log.info("Set ttyType: {}", ttyType);
+	}
+
+	public String getTTYType() {
+		return ttyType;
+	}
+
+	private void setTTYIP (String s) {
+		ttyIP = s;
+		log.info("Set ttyIP: {}", ttyIP);
+	}
+
+	public String getTTYIP() {
+		return ttyIP;
+	}
+
+	private void setTTYPort(String s) {
+		try {
+			ttyPort = Integer.parseInt(s);
+		} catch (NumberFormatException e) {
+			log.error("Wrong Format for Port: {}", s);
+		}
+		log.info("Set TTY Port: {}", ttyPort);
+	}
+
+	public int getTTYPort() {
+		return ttyPort;
+	}
+
 	private void setPort(String s) {
 		try {
 			port = Integer.parseInt(s);
@@ -150,6 +184,12 @@ public class Config {
 		private Thing thing = null;
 		private Channel channel = null;
 		private String path;
+		private String[] urlPort;
+	    final String IPADDRESS_PATTERN =
+	    		"^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." +
+	    		"([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." +
+	    		"([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." +
+	    		"([01]?\\d\\d?|2[0-4]\\d|25[0-5]):([0-9]{1,5})$";
 
 		@Override
 		public void characters(char[] ch, int start, int length)
@@ -157,7 +197,16 @@ public class Config {
 			String s = new String(ch, start, length);
 			switch (path) {
 			case "root.optolink.tty":
-				setTTY(s);
+				if (s.matches(IPADDRESS_PATTERN)) { 	// device is at an URL
+					setTTYType ("URL");
+					setTTY(s);
+					urlPort = s.split(":");
+					setTTYIP (urlPort[0]);
+					setTTYPort (urlPort[1]);
+				} else {								// device is local
+					setTTYType ("GPIO");
+					setTTY(s);
+				}
 				break;
 			case "root.optolink.ttytimeout":
 				setTtyTimeOut(s);

--- a/src/main/java/de/myandres/optolink/Main.java
+++ b/src/main/java/de/myandres/optolink/Main.java
@@ -36,10 +36,10 @@ public class Main {
 			config = new Config("conf/optolink.xml");
 
 			// Init TTY Handling for Optolink
-			optolinkInterface = new OptolinkInterface(config.getTTY(), config.getTtyTimeOut());
+			optolinkInterface = new OptolinkInterface(config);
 
 			// Init ViessmannHandler
-			viessmannHandler = new ViessmannHandler(config.getProtocol(), optolinkInterface);
+			viessmannHandler = new ViessmannHandler(config, optolinkInterface);
 
 		} catch (Exception e) {
 			log.error("Something is wrong not init", e);

--- a/src/main/java/de/myandres/optolink/OptolinkInterface.java
+++ b/src/main/java/de/myandres/optolink/OptolinkInterface.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,7 +77,7 @@ public class OptolinkInterface {
 					socket.close();
 					log.debug("TTY type URL {} closed", this.config.getTTY());
 				} catch (IOException e) {
-					log.debug("TTY type URL {} can´t be closed", this.config.getTTY());
+					log.debug("TTY type URL {} can't be closed", this.config.getTTY());
 				}
 			}
 		} else {
@@ -131,6 +132,9 @@ public class OptolinkInterface {
 			data = input.read();
 			log.trace("RxD: {}", String.format("%02X", data));
 			if (data == -1) log.trace("Timeout from TTY {}", this.config.getTTY());
+			return data;
+		} catch (SocketTimeoutException e) {
+			log.trace("Timeout from TTY {}", this.config.getTTY());
 			return data;
 		} catch (Exception e) {
 			log.error("Can't read Data from TTY {}", this.config.getTTY(), e);

--- a/src/main/java/de/myandres/optolink/OptolinkInterface.java
+++ b/src/main/java/de/myandres/optolink/OptolinkInterface.java
@@ -19,6 +19,7 @@ import gnu.io.SerialPort;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.Socket;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,52 +30,90 @@ public class OptolinkInterface {
 
 	private OutputStream output;
 	private InputStream input;
+	private Config config;
 	private CommPortIdentifier portIdentifier;
 	private CommPort commPort;
-	private String device;
+	private Socket socket = null;
 
 
-	OptolinkInterface(String device, int timeout) throws Exception {
+//TODO implement as runnable for URL-based optolinks	
+	
+	OptolinkInterface(Config config) throws Exception {
 
 		// constructor with implicit open
-
-		this.device = device;
-
-		log.debug("Open TTY {} ...", this.device);
-		portIdentifier = CommPortIdentifier.getPortIdentifier(this.device);
-
-		if (portIdentifier.isCurrentlyOwned()) {
-			log.error("TTY {} in use.", this.device);
-			throw new IOException();
+		this.config = config;
+		if (this.config.getTTYType().matches("URL")) { // device is at an URL
+			open();
+			close();
+			log.debug("TTY type URL is present");
+		} else { // device is local
+			log.debug("Open TTY {} ...", this.config.getTTY());
+			portIdentifier = CommPortIdentifier.getPortIdentifier(this.config.getTTY());
+	
+			if (portIdentifier.isCurrentlyOwned()) {
+				log.error("TTY {} in use.", this.config.getTTY());
+				throw new IOException();
+			}
+			commPort = portIdentifier.open(this.getClass().getName(), this.config.getTtyTimeOut());
+			if (commPort instanceof SerialPort) {
+				SerialPort serialPort = (SerialPort) commPort;
+				serialPort.setSerialPortParams(4800, SerialPort.DATABITS_8,
+						SerialPort.STOPBITS_2, SerialPort.PARITY_EVEN);
+	
+				input = serialPort.getInputStream();
+				output = serialPort.getOutputStream();
+				commPort.enableReceiveTimeout(this.config.getTtyTimeOut()); // Reading Time-Out
+			}
+			log.debug("TTY {} opened", this.config.getTTY());
 		}
-		commPort = portIdentifier.open(this.getClass().getName(), timeout);
-		if (commPort instanceof SerialPort) {
-			SerialPort serialPort = (SerialPort) commPort;
-			serialPort.setSerialPortParams(4800, SerialPort.DATABITS_8,
-					SerialPort.STOPBITS_2, SerialPort.PARITY_EVEN);
-
-			input = serialPort.getInputStream();
-			output = serialPort.getOutputStream();
-			commPort.enableReceiveTimeout(timeout); // Reading Time-Out
-		}
-		log.debug("TTY {} opened", this.device);
 	}
 
 	public synchronized void close() {
-		log.debug("Close TTY {} ....", device);
-		commPort.close();
-		log.debug("TTY {} closed", device);
+		if (this.config.getTTYType().matches("URL")) {
+			log.debug("Close TTY type URL {} ....", this.config.getTTY());
+			if (socket != null) {
+				try {
+					socket.close();
+					log.debug("TTY type URL {} closed", this.config.getTTY());
+				} catch (IOException e) {
+					log.debug("TTY type URL {} can´t be closed", this.config.getTTY());
+				}
+			}
+		} else {
+			log.debug("Close TTY {} ....", this.config.getTTY());
+			commPort.close();
+			log.debug("TTY {} closed", this.config.getTTY());
+		}
+	}
+
+	public synchronized void open() throws Exception {
+		if (this.config.getTTYType().matches("URL")) {
+			log.debug("Open TTY type URL {}", this.config.getTTY());
+			socket = new Socket (this.config.getTTYIP(), this.config.getTTYPort());
+			socket.setSoTimeout (this.config.getTtyTimeOut());
+			input = socket.getInputStream();
+            output = socket.getOutputStream();
+			log.debug("TTY type URL is open");
+		}
 	}
 
 	public synchronized void flush() {
 		// Flush input Buffer
+		if (this.config.getTTYType().matches("URL")) {
+			// We have to wait a certain time. It seems that input.available always has the count 0 
+			// right after connecting 
+			try {
+				Thread.sleep(30); // 10 ms is too low. 30 ms chosen for a certain fail safe distance
+			} catch (InterruptedException e) {
+				log.debug("Error while sleeping to wait for buffer flush");
+			}
+		}
 		try {
 			input.skip(input.available());
 			log.debug("Input Buffer flushed");
 		} catch (IOException e) {
-			log.error("Can't flush TTY: {}", device, e);
+			log.error("Can't flush TTY: {}", this.config.getTTY(), e);
 		}
-
 	}
 
 	public synchronized void write(int data) {
@@ -82,27 +121,26 @@ public class OptolinkInterface {
 		try {
 			output.write((byte) data);
 		} catch (IOException e) {
-			log.error("Can't write Data to TTY {}", device, e);
+			log.error("Can't write Data to TTY {}", this.config.getTTY(), e);
 		}
 	}
 
 	public synchronized int read() {
-		int data;
-
+		int data = -1;
 		try {
 			data = input.read();
 			log.trace("RxD: {}", String.format("%02X", data));
-			if (data == -1) log.trace("Timeout from TTY {}", device);
+			if (data == -1) log.trace("Timeout from TTY {}", this.config.getTTY());
 			return data;
 		} catch (Exception e) {
-			log.error("Can't read Data from TTY {}", device, e);
+			log.error("Can't read Data from TTY {}", this.config.getTTY(), e);
 		}
 		return -1; // Ups
 
 	}
 	
 	public String getDeviceName() {
-		return device;
+		return this.config.getDeviceType();
 	}
 
 }

--- a/src/main/java/de/myandres/optolink/SocketHandler.java
+++ b/src/main/java/de/myandres/optolink/SocketHandler.java
@@ -171,7 +171,7 @@ public class SocketHandler  {
 							    viessmannHandler.setValue(telegram, value.toUpperCase())+
 							    "\"/>");
 			out.println("  </thing>");
-			out.println("<data>");
+			out.println("</data>");
 		}
 		
 	}
@@ -189,7 +189,7 @@ public class SocketHandler  {
 				}
 			}
 			out.println("  </thing>");
-			out.println("<data>");
+			out.println("</data>");
 		}
 	}
 	
@@ -211,7 +211,7 @@ public class SocketHandler  {
 			   }
 			}
 			out.println("  </thing>");
-			out.println("<data>");
+			out.println("</data>");
 		}
 	}
 	

--- a/src/main/java/de/myandres/optolink/SocketHandler.java
+++ b/src/main/java/de/myandres/optolink/SocketHandler.java
@@ -5,7 +5,7 @@
  * are made available under the terms of the GNU Lesser General Public License
  * (LGPL) version 3.0 which accompanies this distribution, and is available at
  * http://www.gnu.org/licenses/lgpl-3.0.html
- *  
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
@@ -14,232 +14,240 @@
 package de.myandres.optolink;
 
 /*
- * Install a Socked Handler for ip communication 
- * 
+ * Install a Socked Handler for ip communication
+ *
  * Server can found via Broadcast
  * Server API Client can connect via TCP
- * 
+ *
  */
- 
+
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.net.ServerSocket;
 import java.net.Socket;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SocketHandler  {
+public class SocketHandler {
 
-	static Logger log = LoggerFactory.getLogger(SocketHandler.class);
+    static Logger log = LoggerFactory.getLogger(SocketHandler.class);
 
-	private Config config;
-	private ServerSocket server;
-	private ViessmannHandler viessmannHandler;
-	private PrintStream out;
-	
+    private Config config;
+    private ServerSocket server;
+    private ViessmannHandler viessmannHandler;
+    private PrintStream out;
 
-	SocketHandler(Config config, ViessmannHandler viessmannHandler) throws Exception {
-		
-		
-		this.config = config;
-		this.viessmannHandler = viessmannHandler;
+    SocketHandler(Config config, ViessmannHandler viessmannHandler) throws Exception {
 
-		server = new ServerSocket(config.getPort());
-	}
+        this.config = config;
+        this.viessmannHandler = viessmannHandler;
 
-      public void start()   {
-    	  
-    	  BroadcastListner broadcastListner = new BroadcastListner(config.getPort(), config.getAdapterID());
-    	  
-    	  // Put broadcast listner in background
-    	  
-    	  Thread broadcastListnerThread = new Thread(broadcastListner);
-    	  broadcastListnerThread.setName("BcListner");
-    	  broadcastListnerThread.start();
-    	  
-    	  
-    	  // Wait connection
-  	  
-    	  while (true) {
-              try {
-            	  log.info("Listen on port {} for connection", config.getPort());
-                  Socket socket = server.accept();
-                  log.info("Connection on port {} accept. Remote host {}", config.getPort(), socket.getRemoteSocketAddress());
-                  open(socket);
-              }
+        server = new ServerSocket(config.getPort());
+    }
 
-              catch (Exception e) {
-      	        log.info("Connection on Socket {} rejected or closed by client", config.getPort());
-              } 
-          } 
-         }
-	
-	
-	private void open(Socket socket) throws Exception {
-		
-		BufferedReader in  = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+    public void start() {
+
+        BroadcastListner broadcastListner = new BroadcastListner(config.getPort(), config.getAdapterID());
+
+        // Put broadcast listner in background
+
+        Thread broadcastListnerThread = new Thread(broadcastListner);
+        broadcastListnerThread.setName("BcListner");
+        broadcastListnerThread.start();
+
+        // Wait connection
+
+        while (true) {
+            try {
+                log.info("Listen on port {} for connection", config.getPort());
+                Socket socket = server.accept();
+                log.info("Connection on port {} accept. Remote host {}", config.getPort(),
+                        socket.getRemoteSocketAddress());
+                open(socket);
+            }
+
+            catch (Exception e) {
+                log.info("Connection on Socket {} rejected or closed by client", config.getPort());
+            }
+        }
+    }
+
+    private void open(Socket socket) throws Exception {
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
         out = new PrintStream(socket.getOutputStream());
 
-        
         out.println("<!-- #Helo from viessmann -->");
         out.println("<optolink>");
-        
+
         String inStr;
-        
-        while(true) {
+
+        while (true) {
             inStr = in.readLine();
-            if (inStr.toLowerCase().startsWith("exit")) break;
-            if (!inStr.equals(null)) new Thread (new CommandExec(inStr)).start();
+            if (inStr.toLowerCase().startsWith("exit")) {
+                break;
+            }
+            if (!inStr.equals(null)) {
+                new Thread(new CommandExec(inStr)).start();
+            }
         }
-        
+
         out.println("<!-- #Bye from viessmann -->");
-		
-	}
 
-	
-	// Start a thread for each call command: No blocking of caller
-	
-	public class CommandExec implements Runnable {
-		
-		String param;
-		
-		CommandExec(String param)
-		{
-			this.param = param;
-		}
+    }
 
-	    public void run() {
-	        String command;
-	        String param1;
-	        String param2;
-	        
-	    	log.debug("Execute Thread for: '{}'", param );
-	        String [] inStr = param.trim().split(" +");
-	        command=inStr[0];
-	        if (inStr.length > 1) param1 = inStr[1]; else param1="";
-	        if (inStr.length > 2) param2 = inStr[2]; else param2="";
-	        exec(command, param1, param2);
-    	    log.debug("Thread for: '{}' done", param );
-	    }
+    // Start a thread for each call command: No blocking of caller
 
+    public class CommandExec implements Runnable {
 
-	        
-	    }
-	    
-	    private synchronized void exec(String command, String param1, String param2 ) {
-	    	
-	        if (log.isTraceEnabled()) {
-                log.trace("Queue Command: |{}|", command);
-                log.trace("      param1 : |{}|", param1);
-                log.trace("      param2 : |{}|", param2);
-           }
-           
-            
-	    	switch (command.toLowerCase()) {
-            
-            case "list" : list(); break;
-            case "get" : if (param2.equals("")) getThing(param1); 
-                         else getThing(param1, param2);
-                         break;
-            case "set" : set(param1, param2); break;
-            default: log.error("Unknown Client Command:", command); 
-            
-            log.trace("Queue Command: |{}| done", command);
-	    	
-	    }
-	    
-	}
+        String param;
 
+        CommandExec(String param) {
+            this.param = param;
+        }
 
+        @Override
+        public void run() {
+            String command;
+            String param1;
+            String param2;
 
-	private void set(String id, String value) {
-		// Format id = <thing>:<channel>
-		
-		String[] ids = id.trim().split(":");
-		
-		if (ids.length != 2) {
-			log.error("Wrong format '{}' of id", id);
-			return;
-		}
-		Telegram telegram = config.getThing(ids[0]).getChannel(ids[1]).getTelegram();
-		if (telegram != null) {
-			out.println("<data>");
-			out.println("  <thing id=\"" + ids[0] + "\">");
+            log.debug("Execute Thread for: '{}'", param);
+            String[] inStr = param.trim().split(" +");
+            command = inStr[0];
+            if (inStr.length > 1) {
+                param1 = inStr[1];
+            } else {
+                param1 = "";
+            }
+            if (inStr.length > 2) {
+                param2 = inStr[2];
+            } else {
+                param2 = "";
+            }
+            exec(command, param1, param2);
+            log.debug("Thread for: '{}' done", param);
+        }
 
-					out.println("    <channel id=\""+ ids[1] +"\" value=\""+ 
-							    viessmannHandler.setValue(telegram, value.toUpperCase())+
-							    "\"/>");
-			out.println("  </thing>");
-			out.println("</data>");
-		}
-		
-	}
+    }
 
-	private void getThing(String id) {
-		log.debug("Try to get Thing for ID: {}", id);
-		Thing thing = config.getThing(id);
-		if (thing != null) {
-			out.println("<data>");
-			out.println("  <thing id=\"" + thing.getId() + "\">");
-			for (Channel channel : thing.getChannelMap()){
-				if (!channel.getId().startsWith("*")) {
-					out.println("    <channel id=\""+ channel.getId() +"\" value=\""+ 
-				                  viessmannHandler.getValue(channel.getTelegram())+"\"/>");
-				}
-			}
-			out.println("  </thing>");
-			out.println("</data>");
-		}
-	}
-	
-	private void getThing(String id, String channels) {
-		Channel channel;
-		log.debug("Try to get Thing for ID: {} channels: {}", id, channels);
-		String[] channelList = channels.split(",");
-		Thing thing = config.getThing(id);
-		if (thing != null) {
-			out.println("<data>");
-			out.println("  <thing id=\"" + thing.getId() + "\">");
-			for (int i=0; i<channelList.length; i++){
-			   channel = thing.getChannel(channelList[i]);
-			   if (channel!=null) {
-					out.println("    <channel id=\""+ channel.getId() +"\" value=\""+ 
-				                  viessmannHandler.getValue(channel.getTelegram())+"\"/>");
-			   } else { 
-				   log.error("Channel : {}.{} not define! ", id, channelList[i] );
-			   }
-			}
-			out.println("  </thing>");
-			out.println("</data>");
-		}
-	}
-	
-	
+    private synchronized void exec(String command, String param1, String param2) {
 
-	private void list() {
-		log.debug("List Things for ID");
-		out.println("<define>");
-		for (Thing thing : config.getThingList()) {
-	
-	    	if ((thing != null) && !thing.getId().startsWith("*") ) {
-			
-			out.println("  <thing id=\"" + thing.getId() + "\" type=\"" + thing.getType() + "\">");
-//			out.println("    <description" + thing.getDescription() + "</description>");
-			for (Channel channel : thing.getChannelMap()) {
-				if (!channel.getId().startsWith("*")) {
-					out.println("    <channel id=\""+ channel.getId() + "\"/>");
-//					out.println("      <description>" + channel.getDescription() + "</description>");
-//					out.println("    </channel>");
-				}
-			}
-			out.println("  </thing>");
-			
-		}
-    	}
-		out.println("</define>");
+        if (log.isTraceEnabled()) {
+            log.trace("Queue Command: |{}|", command);
+            log.trace("      param1 : |{}|", param1);
+            log.trace("      param2 : |{}|", param2);
+        }
 
-	}
+        switch (command.toLowerCase()) {
 
+            case "list":
+                list();
+                break;
+            case "get":
+                if (param2.equals("")) {
+                    getThing(param1);
+                } else {
+                    getThing(param1, param2);
+                }
+                break;
+            case "set":
+                set(param1, param2);
+                break;
+            default:
+                log.error("Unknown Client Command:", command);
+
+                log.trace("Queue Command: |{}| done", command);
+
+        }
+
+    }
+
+    private void set(String id, String value) {
+        // Format id = <thing>:<channel>
+
+        String[] ids = id.trim().split(":");
+
+        if (ids.length != 2) {
+            log.error("Wrong format '{}' of id", id);
+            return;
+        }
+        Telegram telegram = config.getThing(ids[0]).getChannel(ids[1]).getTelegram();
+        if (telegram != null) {
+            out.println("<data>");
+            out.println("  <thing id=\"" + ids[0] + "\">");
+
+            out.println("    <channel id=\"" + ids[1] + "\" value=\""
+                    + viessmannHandler.setValue(telegram, value.toUpperCase()) + "\"/>");
+            out.println("  </thing>");
+            out.println("</data>");
+        }
+
+    }
+
+    private void getThing(String id) {
+        log.debug("Try to get Thing for ID: {}", id);
+        Thing thing = config.getThing(id);
+        if (thing != null) {
+            out.println("<data>");
+            out.println("  <thing id=\"" + thing.getId() + "\">");
+            for (Channel channel : thing.getChannelMap()) {
+                if (!channel.getId().startsWith("*")) {
+                    out.println("    <channel id=\"" + channel.getId() + "\" value=\""
+                            + viessmannHandler.getValue(channel.getTelegram()) + "\"/>");
+                }
+            }
+            out.println("  </thing>");
+            out.println("</data>");
+        }
+    }
+
+    private void getThing(String id, String channels) {
+        Channel channel;
+        log.debug("Try to get Thing for ID: {} channels: {}", id, channels);
+        String[] channelList = channels.split(",");
+        Thing thing = config.getThing(id);
+        if (thing != null) {
+            out.println("<data>");
+            out.println("  <thing id=\"" + thing.getId() + "\">");
+            for (int i = 0; i < channelList.length; i++) {
+                channel = thing.getChannel(channelList[i]);
+                if (channel != null) {
+                    out.println("    <channel id=\"" + channel.getId() + "\" value=\""
+                            + viessmannHandler.getValue(channel.getTelegram()) + "\"/>");
+                } else {
+                    log.error("Channel : {}.{} not define! ", id, channelList[i]);
+                }
+            }
+            out.println("  </thing>");
+            out.println("</data>");
+        }
+    }
+
+    private void list() {
+        log.debug("List Things for ID");
+        out.println("<define>");
+        for (Thing thing : config.getThingList()) {
+
+            if ((thing != null) && !thing.getId().startsWith("*")) {
+
+                out.println("  <thing id=\"" + thing.getId() + "\" type=\"" + thing.getType() + "\">");
+                // out.println(" <description" + thing.getDescription() + "</description>");
+                for (Channel channel : thing.getChannelMap()) {
+                    if (!channel.getId().startsWith("*")) {
+                        out.println("    <channel id=\"" + channel.getId() + "\"/>");
+                        // out.println(" <description>" + channel.getDescription() + "</description>");
+                        // out.println(" </channel>");
+                    }
+                }
+                out.println("  </thing>");
+
+            }
+        }
+        out.println("</define>");
+
+    }
 
 }

--- a/src/main/java/de/myandres/optolink/Telegram.java
+++ b/src/main/java/de/myandres/optolink/Telegram.java
@@ -29,6 +29,7 @@ public class Telegram {
 	public final static byte INT =       6; // 4 byte -> long
     public final static byte UINT =      7; // 4 Byte -> long
     public final static byte DATE =      8; // 8 Byte -> date
+    public final static byte TIMER =     9; // 8 Byte -> timer
     public final static byte DUMP =      99; // Dump for unknown Telegram-Type
 
     
@@ -116,6 +117,10 @@ public class Telegram {
 				break;
 			case "date":
 				this.type = Telegram.DATE;
+				length=8;
+				break;
+			case "timer":
+				this.type = Telegram.TIMER;
 				length=8;
 				break;
 			default: {

--- a/src/main/java/de/myandres/optolink/Viessmann300.java
+++ b/src/main/java/de/myandres/optolink/Viessmann300.java
@@ -53,17 +53,17 @@ public class Viessmann300 implements ViessmannProtocol {
            if ( transmit(localBuffer,5)) {;         // send Buffer 
 
             // RxD
-            returNumberOfBytes = resive(localBuffer);  // read answer 
+            returNumberOfBytes = receive(localBuffer);  // read answer 
             
             if (returNumberOfBytes > 0) {
 
                 // check RxD 
                int returnAddress;
                if (localBuffer[0] == 0x03) log.error("Answer Byte is 0x03: Return Error(Wrong Adress,maybe)");
-               if (localBuffer[0] != 0x01) log.error("Answer Byte (0x01) expect, but: 0x{} resived", String.format("%02X", localBuffer[0]));
-               if (localBuffer[1] != 0x01) log.error("DataRead Byte (0x01) expect, but: 0x{} resived", String.format("%02X",buffer[1]));
+               if (localBuffer[0] != 0x01) log.error("Answer Byte (0x01) expect, but: 0x{} received", String.format("%02X", localBuffer[0]));
+               if (localBuffer[1] != 0x01) log.error("DataRead Byte (0x01) expect, but: 0x{} received", String.format("%02X",buffer[1]));
                returnAddress = ((localBuffer[2] & 0xFF) << 8) + ((int)localBuffer[3] & 0xFF); // Address
-               if (returnAddress != address) log.error(String.format("Adress (%04X) expect, but: %04X resived", address, returnAddress));
+               if (returnAddress != address) log.error(String.format("Adress (%04X) expect, but: %04X received", address, returnAddress));
                for (int j=0;j<localBuffer[4];j++) buffer[j] =localBuffer[j+5];  // copy Result 
                log.debug(String.format("Data for address %04X got ", address)); 
                return (returNumberOfBytes-5); // buffer length
@@ -110,7 +110,7 @@ public class Viessmann300 implements ViessmannProtocol {
        if ( transmit(localBuffer,5+length)) {;         // send Buffer 
 
         // RxD
-        returNumberOfBytes = resive(localBuffer);  // read answer 
+        returNumberOfBytes = receive(localBuffer);  // read answer 
         
         if (returNumberOfBytes > 0) {
 
@@ -119,14 +119,14 @@ public class Viessmann300 implements ViessmannProtocol {
            if (localBuffer[0] == 0x03) 
         	   log.error("Answer Byte is 0x03: Return Error(Wrong Adress,maybe)");
            if (localBuffer[0] != 0x01) 
-        	   log.error("Answer Byte (0x01) expect, but: 0x{} resived", 
+        	   log.error("Answer Byte (0x01) expect, but: 0x{} received", 
         			   String.format("%02X", localBuffer[0]));
            if (localBuffer[1] != 0x02) 
-        	   log.error("Data Write Byte (0x02) expect, but: 0x{} resived",
+        	   log.error("Data Write Byte (0x02) expect, but: 0x{} received",
         			   String.format("%02X",buffer[1]));
            returnAddress = ((localBuffer[2] & 0xFF) << 8) + ((int)localBuffer[3] & 0xFF); // Address
            if (returnAddress != address) 
-        	   log.error(String.format("Adress (%04X) expect, but: %04X resived", address, returnAddress));
+        	   log.error(String.format("Adress (%04X) expect, but: %04X received", address, returnAddress));
            for (int j=0;j<localBuffer[4];j++) buffer[j] =localBuffer[j+5];  // copy Result 
            log.debug(String.format("Data for address %04X got ", address)); 
            return (localBuffer[4]); // buffer length
@@ -179,7 +179,7 @@ public class Viessmann300 implements ViessmannProtocol {
         	optolinkInterface.write(0x04);              //  close communication
             ret = optolinkInterface.read();
             if (ret == 0x06) {
-                  log.trace("[ACK] resived");
+                  log.trace("[ACK] received");
               log.debug("Session to optolink closed");
               return; // Close  OK
             }
@@ -193,7 +193,7 @@ public class Viessmann300 implements ViessmannProtocol {
 }
 
     // RxD Telegram
-    private synchronized int resive(byte[] buffer) {
+    private synchronized int receive(byte[] buffer) {
             log.debug("Get Data from OptolinkInterface ...");
             int ret=optolinkInterface.read();
             if (ret != 0x41) {
@@ -214,7 +214,7 @@ public class Viessmann300 implements ViessmannProtocol {
             returnChecksum = returnChecksum & 0xFF;         //expected checksum 8 low bit's .
             int bufferChecksum=optolinkInterface.read();    // read checksum 
             if (returnChecksum != bufferChecksum) {
-            	log.error(String.format("Checksumme (%#02X) expect, but %#02X resived", returnChecksum, bufferChecksum));
+            	log.error(String.format("Checksumme (%#02X) expect, but %#02X received", returnChecksum, bufferChecksum));
             }
             log.debug("Data from OptolinkInterface got [OK]");
             if (log.isTraceEnabled()) {
@@ -253,9 +253,9 @@ public class Viessmann300 implements ViessmannProtocol {
             //  Wait for Acknowledge (0x06)
             int ret =optolinkInterface.read();
             if (ret != 0x06){
-                    log.error(String.format("acknowledge (0x06) expect, but: %02X resived", ret));
+                    log.error(String.format("acknowledge (0x06) expect, but: %02X received", ret));
                     if (ret == 0x05) {
-                    	log.info(String.format("0x05 resived: Session maybe stoped! Try to restart session"));
+                    	log.info(String.format("0x05 received: Session maybe stopped! Try to restart session"));
                     	startSession();
                     }
                     return false;

--- a/src/main/java/de/myandres/optolink/ViessmannHandler.java
+++ b/src/main/java/de/myandres/optolink/ViessmannHandler.java
@@ -79,7 +79,7 @@ public class ViessmannHandler {
 				switchTimes[switchTimesLength++] = matcher.group(1);
 			}
 
-			if (switchTimesLength != 0 & (switchTimesLength % 2) == 0) {
+			if ((switchTimesLength % 2) == 0) {
 				for (int i = 0; i<switchTimesLength; i++) {
 					timeParts = switchTimes[i].split(":");
 					hr = Integer.parseInt(timeParts[0]);

--- a/src/main/java/de/myandres/optolink/ViessmannKW.java
+++ b/src/main/java/de/myandres/optolink/ViessmannKW.java
@@ -45,7 +45,7 @@ public class ViessmannKW implements ViessmannProtocol {
         	}
         
         }    
-        optolinkInterface.write(0x01); // Anwser to 0x05
+        optolinkInterface.write(0x01); // Answer to 0x05
         optolinkInterface.write(0xF7); // Read Data
         optolinkInterface.write((byte)(address >> 8));   // upper Byte of address
         optolinkInterface.write((byte)(address & 0xff)); // lower Byte of address
@@ -68,7 +68,6 @@ public class ViessmannKW implements ViessmannProtocol {
 
 	@Override
 	public int setData(byte[] buffer, int address, int length, int value) {
-		// TODO Test it
 		
 		int j=0;
 		optolinkInterface.flush();
@@ -81,17 +80,25 @@ public class ViessmannKW implements ViessmannProtocol {
         	}
         
         }    
-        optolinkInterface.write(0x01); // Anwser to 0x05
+        optolinkInterface.write(0x01); // Answer to 0x05
         optolinkInterface.write(0xF4); // write Data
         optolinkInterface.write((byte)(address >> 8));   // upper Byte of address
         optolinkInterface.write((byte)(address & 0xff)); // lower Byte of address
         optolinkInterface.write((byte)length);           // number of expected bytes
-        
-        for (int i=0; i<length; i++) {
-        	buffer[i] = (byte) optolinkInterface.read();
-        } 
-        return length;
-		
+        switch (length) {
+        case 1: optolinkInterface.write(buffer[0]); 	 // write lower byte
+        		break;
+        case 8: optolinkInterface.write(buffer[0]); // Timer data has length 8
+        		optolinkInterface.write(buffer[1]);
+        		optolinkInterface.write(buffer[2]);
+        		optolinkInterface.write(buffer[3]);
+        		optolinkInterface.write(buffer[4]);
+        		optolinkInterface.write(buffer[5]);
+        		optolinkInterface.write(buffer[6]);
+        		optolinkInterface.write(buffer[7]);
+        		break;
+        }
+		return length;
 	}
 
 }

--- a/src/main/resources/optolink-ob.xml
+++ b/src/main/resources/optolink-ob.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Mapping for vitotronic/optolink addresses to openhab things.
+
+channel id starts with '*' :
+     -    will not send to openhab but it is posible to ask for this ID on the interface.
+     -    is not implemented in openhab
+     
+Telegram types:
+	BOOLEAN = 1 Byte -> boolean
+	BYTE    = 1 Byte -> short
+	UBYTE   = 1 Byte -> short
+	SHORT   = 2 Byte -> int
+	USHORT  = 2 Byte -> int
+	INT     = 4 byte -> long
+    UINT    = 4 Byte -> long
+    DATE    = 8 Byte -> date (read only)
+	TIMER	= 8 Byte -> timer
+    
+For more information about addresses and types see: http://openv.wikispaces.com/
+
+-->
+
+
+
+<optolink device="20cb" id="200" protocol="KW">
+
+     <adapterID>VScotH01</adapterID>        <!-- Unique ID on the Network-->
+     <tty>192.168.178.25:10001</tty>        <!-- serial port of the optolink adapter-->
+     <ttytimeout>2000</ttytimeout>           <!-- milliseconds for reading timeout tty -->
+     <port>31113</port>                      <!-- port for incoming communication. See also: http://www.iana.org -->
+
+     <!-- Addressen die von diesem 'device' unterstützt werden -->
+    
+     <thing type="heating" id="300W">
+          <description>Viessmann Vitodens 300-W</description>
+          <channel  id="*systemid">
+               <description>System ID</description>
+               <telegram address="00F8" type="short"/>
+          </channel>
+          <channel id="systemtime">
+               <description>System Date and Time</description>
+               <telegram address="088E" type="date" />
+          </channel>
+          <channel id="outside_temp">
+               <description>Outside Temperature</description>
+               <telegram address="0800" type="short" divider="10"/>
+          </channel>
+          <channel id="malfunction">
+               <description>General malfunction heating</description>
+               <telegram address="0A82" type="boolean"/>
+          </channel>
+     </thing>
+     <!--# Puffer-StorageTank -->
+     <thing type="storagetank" id="storagetank">
+          <description>Hot Water Storage Tank an Buffer</description>
+          <channel id="hotwater_temp">
+               <description>Hot water temperature.</description>
+               <telegram  address="0804" type="short" divider="10"/>
+          </channel>
+          <channel id="hotwater_set_temp">
+               <description>Hot water temperatur target temperature.</description>
+               <telegram  address="6300" type="byte" divider="1"/>
+          </channel>
+          <channel id="circuitpump">
+               <description>Cirulation Pump for Hot Water TODO which pump?</description>
+               <telegram  address="0490" type="boolean" />
+          </channel>
+    </thing>
+
+    <!--# Burner -->
+    <thing type="burner" id="burner">
+          <description>Burner</description>
+           <channel id="power">
+               <description>The furnace Power in %</description>
+               <telegram address="A38F" type="ubyte" divider="1"/>
+          </channel>
+          <channel id="exhaust_temp">
+               <description>Exhaust temperature</description>
+               <telegram address="0808" type="short" divider="10"/>
+          </channel>
+          <channel id="boiler_temp">
+               <description>Boiler temperature</description>
+               <telegram address="0810" type="short" divider="10"/>
+          </channel>
+          <channel id="*stat">
+              <!-- Brennerstatus ist noch nicht klar Addresse noch gesucht -->
+               <description>State of Burner </description>
+               <telegram  address="0962" type="short" />
+          </channel>
+     </thing>
+
+        <!--# Heizkreis 2 -->
+    <thing type="circuit" id="circuit2">
+          <description>Heading Circuit of the first Floor.</description>
+          <channel id="flowtemperature" >
+               <description>Flow temperature</description>
+               <telegram address="3900" type="short" divider="10"/>
+          </channel>
+          <channel id="pump">
+               <description>pump</description>
+               <telegram  address="3906" type="boolean" />
+          </channel>
+           <channel id="operationmode" >
+               <description>Operation mode (0,1,2,3,4).</description>
+               <telegram address="3500" type="byte"/>
+         </channel>
+          <channel id="room_temp">
+               <description>Inside Temperature</description>
+               <telegram address="0898" type="short" divider="10"/>
+          </channel>
+         <channel id="room_set_temp" >
+               <description>Room Set temperature.</description>
+               <telegram address="3306" type="byte"/>
+         </channel>
+         <channel id="timer_MO" >
+               <description>Timer Monday</description>
+               <telegram address="3000" type="timer"/>
+         </channel>
+         <channel id="timer_TU" >
+               <description>Timer Tuesday</description>
+               <telegram address="3008" type="timer"/>
+         </channel>
+         <channel id="timer_WE" >
+               <description>Timer Wednesday</description>
+               <telegram address="3010" type="timer"/>
+         </channel>
+         <channel id="timer_TH" >
+               <description>Timer Thursday</description>
+               <telegram address="3018" type="timer"/>
+         </channel>
+         <channel id="timer_FR" >
+               <description>Timer Friday</description>
+               <telegram address="3020" type="timer"/>
+         </channel>
+         <channel id="timer_SA" >
+               <description>Timer Saturday</description>
+               <telegram address="3028" type="timer"/>
+         </channel>
+         <channel id="timer_SU" >
+               <description>Timer Sunday</description>
+               <telegram address="3030" type="timer"/>
+         </channel>
+         <channel id="timer_ww_MO" >
+               <description>Timer Monday</description>
+               <telegram address="2100" type="timer"/>
+         </channel>
+         <channel id="timer_ww_TU" >
+               <description>Timer Tuesday</description>
+               <telegram address="2108" type="timer"/>
+         </channel>
+         <channel id="timer_ww_WE" >
+               <description>Timer Wednesday</description>
+               <telegram address="2110" type="timer"/>
+         </channel>
+         <channel id="timer_ww_TH" >
+               <description>Timer Thursday</description>
+               <telegram address="2118" type="timer"/>
+         </channel>
+         <channel id="timer_ww_FR" >
+               <description>Timer Friday</description>
+               <telegram address="2120" type="timer"/>
+         </channel>
+         <channel id="timer_ww_SA" >
+               <description>Timer Saturday</description>
+               <telegram address="2128" type="timer"/>
+         </channel>
+         <channel id="timer_ww_SU" >
+               <description>Timer Sunday</description>
+               <telegram address="2130" type="timer"/>
+         </channel>
+	 </thing>
+</optolink>


### PR DESCRIPTION
Optolink adapters behind an IP-serial converter (i.e. Lantronix XPort) can be included by adding an IP:port string as tty in the optolink.xml file.
I included an example-xml under src/main/resources.
Furthermore my Vitotronic_200_Typ_HO1 uses different things/channels. This is also included in the example-xml.